### PR TITLE
Use bot.loop.create_task for cog_unload

### DIFF
--- a/amarilevel/amarilevel.py
+++ b/amarilevel/amarilevel.py
@@ -11,8 +11,8 @@ class AmariLevel(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def cog_unload(self):
-        await self.amari.close()
+    def cog_unload(self):
+        self.bot.loop.create_task(self.amari.close())
 
     @commands.command()
     async def amari(self, ctx, *member: discord.Member):


### PR DESCRIPTION
This will fix `RuntimeWarning: coroutine 'AmariLevel.cog_unload' was never awaited` since the current red version didn't support async cog_unload yet.