### PR TITLE
Fix user being None

### DIFF
--- a/amarilevel/amarilevel.py
+++ b/amarilevel/amarilevel.py
@@ -26,7 +26,7 @@ class AmariLevel(commands.Cog):
             bot_info = await self.bot.application_info()
             amari = AmariClient(token)
             try:
-                lb = await amari.fetch_leaderboard(ctx.guild.id)
+                lb = await amari.fetch_full_leaderboard(ctx.guild.id)
                 user = lb.get_user(member.id)
                 e = discord.Embed(
                     title=f"{member.name}'s Amari Rank",


### PR DESCRIPTION
This should prevent the user from being None and causing error

![image](https://user-images.githubusercontent.com/57430307/193754664-fda6c347-5cfd-44b7-acfd-d7e64173b23a.png)
