### PR TITLE
Fixed emoji not showing if bot is not in server.

### DIFF
--- a/reactionlog/reactionlog.py
+++ b/reactionlog/reactionlog.py
@@ -103,7 +103,8 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
-            embed.set_thumbnail(url=reaction.emoji.url)
+            if isinstance(reaction.emoji, discord.Emoji) or isinstance(reaction.emoji, discord.PartialEmoji):
+                embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 
     @commands.Cog.listener()
@@ -126,7 +127,8 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
-            embed.set_thumbnail(url=reaction.emoji.url)
+            if isinstance(reaction.emoji, discord.Emoji) or isinstance(reaction.emoji, discord.PartialEmoji):
+                embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 
     @commands.Cog.listener()

--- a/reactionlog/reactionlog.py
+++ b/reactionlog/reactionlog.py
@@ -103,6 +103,7 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
+            embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 
     @commands.Cog.listener()
@@ -125,6 +126,7 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
+            embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 
     @commands.Cog.listener()

--- a/reactionlog/reactionlog.py
+++ b/reactionlog/reactionlog.py
@@ -103,7 +103,9 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
-            if isinstance(reaction.emoji, discord.Emoji) or isinstance(reaction.emoji, discord.PartialEmoji):
+            if isinstance(reaction.emoji, discord.Emoji) or isinstance(
+                reaction.emoji, discord.PartialEmoji,
+            ):
                 embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 
@@ -127,7 +129,9 @@ class ReactionLog(commands.Cog):
                 value=f"[Click here]({reaction.message.jump_url})",
                 inline=False,
             )
-            if isinstance(reaction.emoji, discord.Emoji) or isinstance(reaction.emoji, discord.PartialEmoji):
+            if isinstance(reaction.emoji, discord.Emoji) or isinstance(
+                reaction.emoji, discord.PartialEmoji,
+            ):
                 embed.set_thumbnail(url=reaction.emoji.url)
             await logs.send(embed=embed)
 


### PR DESCRIPTION
This pull request allows bot to show emoji as a thumbnail even if the bot isn't in the server.